### PR TITLE
Directly plot GeoJSON using MongoDB's Simple REST API

### DIFF
--- a/web/map/leaflet_moon.html
+++ b/web/map/leaflet_moon.html
@@ -84,6 +84,7 @@ var popup = null;
   };
 
   L.control.layers(baseLayers).addTo(map);
+  let geoJSONLayer = L.geoJSON().addTo(map);
 
 
 

--- a/web/map/leaflet_moon.html
+++ b/web/map/leaflet_moon.html
@@ -145,4 +145,7 @@ window.onload = function(){
 
 };
 </script>
+
+<script src="src/db.js"></script>
+<script src="src/main.js"></script>
 </html>

--- a/web/map/src/db.js
+++ b/web/map/src/db.js
@@ -1,0 +1,16 @@
+function getQuery() {
+    const URL = "localhost";
+    const PORT = 28017;
+    const DB = "selene";
+    const COLLECTION = "images";
+
+    queryString = $.param({
+        limit: 100
+    })
+    // console.log(queryString);
+    uriQuery = `http://${URL}:${PORT}/${DB}/${COLLECTION}/?${queryString}`;
+
+    let xmlRequest = $.ajax(uriQuery);
+
+    return $.ajax(uriQuery, { dataType: "json" });
+}

--- a/web/map/src/main.js
+++ b/web/map/src/main.js
@@ -1,0 +1,5 @@
+$(window).on("load", () => {
+    getQuery()
+        .done(data => console.log(data.rows))
+        .fail((_, status) => console.error(status));
+});

--- a/web/map/src/main.js
+++ b/web/map/src/main.js
@@ -1,5 +1,15 @@
 $(window).on("load", () => {
     getQuery()
-        .done(data => console.log(data.rows))
+        .done(data => {
+            console.log(data.rows);
+            plotPoints(geoJSONLayer, data.rows);
+        })
         .fail((_, status) => console.error(status));
 });
+
+function plotPoints(geoJSONLayer, data) {
+    // Grab the points of every element.
+    let geoDataPoints = data.map(elem => elem.loc);
+    console.log(geoDataPoints);
+    geoJSONLayer.addData(geoDataPoints);
+}


### PR DESCRIPTION
Performs an AJAX to MongoDB's built-in REST API then adds the points to a GeoJSON layer on Leaflet.
* Requires enabling the REST API on the database by editing the config or by the parameter `--rest`